### PR TITLE
use privateRPCUrls

### DIFF
--- a/firebase/functions/package.json
+++ b/firebase/functions/package.json
@@ -25,7 +25,7 @@
         "@sendgrid/mail": "^7.7.0",
         "@types/fluent-ffmpeg": "^2.1.20",
         "@types/mkdirp": "^1.0.2",
-        "@wormgraph/helpers": "0.7.3-prod-3",
+        "@wormgraph/helpers": "0.7.3-prod-4",
         "@wormgraph/manifest": "0.7.4-demo-2",
         "axios": "^1.1.2",
         "ethers": "^5.7.1",

--- a/firebase/functions/src/functions/email.ts
+++ b/firebase/functions/src/functions/email.ts
@@ -169,17 +169,19 @@ export const enqueueLootboxDepositEmail = functions
         }
 
         const chain = BLOCKCHAINS[chainSlug];
-        if (!chain || !chain?.rpcUrls[0]) {
+        const rpcURL = chain?.privateRPCUrls[0] || chain?.rpcUrls[0];
+
+        if (!chain || !rpcURL) {
             logger.error("Chain not found", {
                 caller: context.auth.uid,
                 chainIdHex: data.chainIDHex,
                 chainSlug,
                 rpcUrls: chain?.rpcUrls,
+                privateRPCUrls: chain.privateRPCUrls,
             });
             throw new functions.https.HttpsError("not-found", "Chain not found");
         }
-
-        const provider = new ethers.providers.JsonRpcProvider(chain.rpcUrls[0]);
+        const provider = new ethers.providers.JsonRpcProvider(rpcURL);
 
         const tokenData: {
             [key: Address]: {
@@ -226,7 +228,6 @@ export const enqueueLootboxDepositEmail = functions
         let lootboxDeposits: Deposit[] = [];
         try {
             // Get all deposit information about the lootbox
-            // const provider = new ethers.providers.JsonRpcProvider(chain.rpcUrls[0]);
             logger.info("Getting lootbox data", { lootboxAddress: lootbox.address, chain });
             const lootboxContract = new ethers.Contract(lootbox.address, LootboxCosmicABI, provider);
             logger.info("Getting lootbox deposits", { lootboxAddress: lootbox.address, chain });

--- a/firebase/functions/src/functions/lootbox.ts
+++ b/firebase/functions/src/functions/lootbox.ts
@@ -71,7 +71,7 @@ export const indexLootboxOnCreate = functions
         logger.info("indexLootboxOnCreate", { data });
         // Any errors thrown or timeouts will trigger a retry
         // Start a listener to listen for the event
-        const rpcURL = data.chain.rpcUrls[0];
+        const rpcURL = data.chain.privateRPCUrls[0] || data.chain.rpcUrls[0];
         const provider = new ethers.providers.JsonRpcProvider(rpcURL);
         const lootboxFactory = new ethers.Contract(data.payload.factory, LootboxCosmicFactoryABI, provider);
 
@@ -366,9 +366,10 @@ export const indexLootboxOnMint = functions
     .onDispatch(async (data: IndexLootboxOnMintTaskRequest) => {
         logger.info("indexLootboxOnMint", { data });
         // Any errors thrown or timeouts will trigger a retry
+        const rpcURL = data.chain.privateRPCUrls[0] || data.chain.rpcUrls[0];
 
         // Start a listener to listen for the event
-        const provider = new ethers.providers.JsonRpcProvider(data.chain.rpcUrls[0]);
+        const provider = new ethers.providers.JsonRpcProvider(rpcURL);
 
         logger.info("creating lootbox contract");
 

--- a/firebase/functions/yarn.lock
+++ b/firebase/functions/yarn.lock
@@ -1933,10 +1933,10 @@
     axios "0.25.0"
     lodash "4.17.21"
 
-"@wormgraph/helpers@0.7.3-prod-3":
-  version "0.7.3-prod-3"
-  resolved "https://registry.npmjs.org/@wormgraph/helpers/-/helpers-0.7.3-prod-3.tgz"
-  integrity sha512-jNmdsMtW/RM4cnomkurSIXnOL9ScTYnmQAn6wM2u/U7k5Te7nVljw/d4nl1stZRTJtvvlqVJyzlcQZfw1maGCA==
+"@wormgraph/helpers@0.7.3-prod-4":
+  version "0.7.3-prod-4"
+  resolved "https://registry.yarnpkg.com/@wormgraph/helpers/-/helpers-0.7.3-prod-4.tgz#b1e63f65c094d4a85364dcaf4a3b470f408cfbd3"
+  integrity sha512-9ZT+hdIrVuex2oLELY7Fi89vjVQ+frbxed9sKGkrVGnybUE8oeNStFsAS8qh2DSBB6+QHrxbKM2WYvOzXPs+1Q==
   dependencies:
     axios "0.25.0"
     lodash "4.17.21"


### PR DESCRIPTION
Put our quicknode RPCs into a different spot because i think the frontend uses `rpcUrls` to add a network lol - dont want to add our quicknode RPC to peoples walelt 

TODO: hide the api key, currently clients can still access these from installed helpers